### PR TITLE
Drop java installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Requirements
 
 Role Variables
 --------------
-```markdown
+```yml
 ---
 # vars file for spigot role
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,15 +1,5 @@
 ---
 # tasks file for spigot
-- name: install java (RedHat)
-  package:
-     name: java-11-openjdk
-  when:  ansible_os_family == 'RedHat'
-
-- name: install java (Debian)
-  package:
-     name: openjdk-11-jdk
-  when:  ansible_os_family == 'Debian'
-
 - name: install git
   package:
      name: git

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 # tasks file for spigot
+
 - name: install git
   package:
      name: git
-  when:  ansible_os_family == 'RedHat'
 
 - name: create minecraft admin user
   user:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,7 @@
     args:
       warn: false
   - name: building spigot tools
-    command: "java -jar BuildTools.jar --rev latest --output-dir {{ spigot_dir }}/server"
+    command: "{java_path} -jar BuildTools.jar --rev latest --output-dir {{ spigot_dir }}/server"
     args:
         chdir: "{{ spigot_dir }}"
   - name: copy eula.txt
@@ -45,7 +45,7 @@
       src: plugins
       dest: "{{ spigot_dir }}/server"
   - name: running server
-    command: nohup java -Xms{{ gigs }}G -Xmx{{ gigs }}G -XX:+UseConcMarkSweepGC -jar spigot*.jar </dev/null >/dev/null 2>&1 &
+    command: nohup {java_path} -Xms{{ gigs }}G -Xmx{{ gigs }}G -XX:+UseConcMarkSweepGC -jar spigot*.jar </dev/null >/dev/null 2>&1 &
     args:
       chdir: "{{ spigot_dir }}/server"
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -10,4 +10,9 @@ spigot_dir: $HOME/spigot
 #default ram used by server instance in gigabytes
 gigs: 2
 
+#server operators
 op_users: []
+
+#path that java is installed at
+#defaults to attempt useing PATH variable
+java_path: "java"


### PR DESCRIPTION
java is too cumbersome to safely install and manage via this script with out breaking environment.
users can install their own java.